### PR TITLE
Replace bespoke converters with implementations of From and TryFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For example:
 
 ```rust
 // Create a bitset of width 8, with three fields a, b and c.
-let mut x = BitSet::<8>::from_int(0b1_0101_111).unwrap();
+let mut x = BitSet::<8>::from(0b1_0101_111);
 //                                  ^    ^   ^
 //                                  c    b   a
 
@@ -19,18 +19,18 @@ let mut x = BitSet::<8>::from_int(0b1_0101_111).unwrap();
 let a: BitSet<3> = x.get_field::<3, 0>().unwrap();
 let b: BitSet<4> = x.get_field::<4, 3>().unwrap();
 let c: BitSet<1> = x.get_field::<1, 7>().unwrap();
-assert_eq!(a.to_int(), 0b111);
-assert_eq!(b.to_int(), 0b0101);
-assert_eq!(c.to_int(), 0b1);
+assert_eq!(u8::from(a), 0b111);
+assert_eq!(u8::from(b), 0b0101);
+assert_eq!(u8::from(c), 0b1);
 
 // Now set a feild. Note that setting a field requires a bitset with the
 // correct width.
 let b = BitSet::<4>::from_int(0b1010).unwrap();
 x.set_field::<4, 3>(b).unwrap();
-assert_eq!(a.to_int(), 0b111);
-assert_eq!(b.to_int(), 0b1010);
-assert_eq!(c.to_int(), 0b1);
-assert_eq!(x.to_int(), 0b1_1010_111);
+assert_eq!(u8::from(a), 0b111);
+assert_eq!(u8::from(b), 0b1010);
+assert_eq!(u8::from(c), 0b1);
+assert_eq!(u8::from(x), 0b1_1010_111);
 ```
 
 This crate requires nightly Rust with the `generic_const_exprs` feature.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -47,14 +47,8 @@ where
 }
 
 impl BitSet<1> {
-    pub const TRUE: Self = Self::from_bool(true);
-    pub const FALSE: Self = Self::from_bool(false);
-}
-
-impl From<bool> for BitSet<1> {
-    fn from(value: bool) -> Self {
-        Self::from_bool(value)
-    }
+    pub const TRUE: Self = Self([1u8]);
+    pub const FALSE: Self = Self([0u8]);
 }
 
 impl<const BITS: usize> TryFrom<&Vec<u8>> for BitSet<BITS>
@@ -339,12 +333,15 @@ macro_rules! display {
     };
 }
 
-impl BitSet<1> {
-    pub const fn from_bool(value: bool) -> Self {
-        Self([value as u8])
+impl From<BitSet<1>> for bool {
+    fn from(value: BitSet<1>) -> Self {
+        value.0[0] == 1
     }
-    pub const fn to_bool(&self) -> bool {
-        self.0[0] == 1
+}
+
+impl From<bool> for BitSet<1> {
+    fn from(value: bool) -> Self {
+        Self([value as u8])
     }
 }
 
@@ -614,7 +611,7 @@ mod test {
         assert_eq!(x, y);
 
         let x = BitSet::<64>::try_from(&bytes).unwrap();
-        let y = BitSet::<64>::try_from(0xab8967452301u64).unwrap();
+        let y = BitSet::<64>::from(0xab8967452301u64);
         assert_eq!(x, y);
 
         assert!(BitSet::<32>::try_from(&bytes).is_err());


### PR DESCRIPTION
Support conversion to/from byte slices, to better support larger types

Downstream, this leads to things like:
```
Self(BitSet::<32>::from_int(value).unwrap())
```
turning into:
```
Self(BitSet::<32>::from(value))
```