### PR TITLE
no_std support, infallible get/set/mask field operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ For example:
 ```rust
 // Create a bitset of width 8, with three fields a, b and c.
 let mut x = BitSet::<8>::from(0b1_0101_111);
-//                                  ^    ^   ^
-//                                  c    b   a
+//                              ^    ^   ^
+//                              c    b   a
 
 // Extract individual fields. Note that the extracted field is statically
 // typed according to width.
-let a: BitSet<3> = x.get_field::<3, 0>().unwrap();
-let b: BitSet<4> = x.get_field::<4, 3>().unwrap();
-let c: BitSet<1> = x.get_field::<1, 7>().unwrap();
+let a: BitSet<3> = x.get_field::<3, 0>();
+let b: BitSet<4> = x.get_field::<4, 3>();
+let c: BitSet<1> = x.get_field::<1, 7>();
 assert_eq!(u8::from(a), 0b111);
 assert_eq!(u8::from(b), 0b0101);
 assert_eq!(u8::from(c), 0b1);
 
 // Now set a feild. Note that setting a field requires a bitset with the
 // correct width.
-let b = BitSet::<4>::from_int(0b1010).unwrap();
-x.set_field::<4, 3>(b).unwrap();
+let b = bitset!(4, 0b1010);
+x.set_field::<4, 3>(b);
 assert_eq!(u8::from(a), 0b111);
 assert_eq!(u8::from(b), 0b1010);
 assert_eq!(u8::from(c), 0b1);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -139,6 +139,7 @@ where
     where
         [(); ((FBITS - 1) >> 3) + 1]:,
         [(); BITS - FBITS]:,
+        [(); BITS - (OFFSET + FBITS)]:,
     {
         assert!(FBITS <= BITS);
         let sub =
@@ -177,6 +178,7 @@ where
         [(); ((FBITS - 1) >> 3) + 1]:,
         [(); (((FBITS + OFFSET) - 1) >> 3) + 1]:,
         [(); BITS - FBITS]:,
+        [(); BITS - (OFFSET + FBITS)]:,
     {
         let m = BitSet::<FBITS>::max();
         let mut mask = BitSet::<BITS>::default();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -102,26 +102,34 @@ where
 
     fn mask(&mut self) {
         let mask = ((1 << (BITS % 8)) - 1) as u8;
-        // The array len is ((BITS-1) >> 3) + 1
-        // Can assume that BITS >> 3 is always less than ((BITS-1) >> 3) + 1?
-        //
-        // Math:
-        // b >> 3 < ((b-1) >> 3) + 1
-        //
-        // treat b>>3 as b/3 so we can use normal math
-        //
-        // b/8 < ((b-1)/8) + 1
-        // b/8 - (b-1)/8 < 1
-        // b - (b-1) < 8
-        // b - b + 1 < 8
-        // 1 < 8 ✓
-        //
-        // This holds for >>, since x>>3 <= x/3 as x>>3 is x/8 with truncation.
         let pos = BITS >> 3;
         if mask == 0 {
             return;
         }
 
+        // Index safety:
+        //
+        // The array len is ((BITS-1) >> 3) + 1. Can we assume that
+        // pos = BITS >> 3 is always less than ((BITS-1) >> 3) + 1?
+        //
+        // The following analysis shows we can.
+        //
+        // Start with what we want to show.
+        //
+        //   b >> 3 < ((b-1) >> 3) + 1
+        //
+        // Treat b>>3 as b/8 so we can use normal math. The result holds for >>
+        // as x>>3 <= x/3 because x>>3 is x/8 with truncation.
+        //
+        //   b/8 < ((b-1)/8) + 1
+        //
+        // Now simplify.
+        //
+        //   b/8 - (b-1)/8 < 1
+        //   b - (b-1) < 8
+        //   b - b + 1 < 8
+        //   1 < 8 ✓
+        //
         self.0[pos] &= mask;
     }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -693,7 +693,7 @@ mod test {
         assert_eq!(u8::from(b), 0b0101);
         assert_eq!(u8::from(c), 0b1);
 
-        // Now set a feild. Note that setting a field requires a bitset with the
+        // Now set a field. Note that setting a field requires a bitset with the
         // correct width.
         let b = bitset!(4, 0b1010);
         x.set_field::<4, 3>(b);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,12 +1,15 @@
 // Copyright Oxide Computer Company 2025
-
+#![no_std]
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 #![allow(clippy::unusual_byte_groupings)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::error::Error;
+use core::fmt::Display;
 use seq_macro::seq;
-use std::error::Error;
-use std::fmt::Display;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BitSet<const BITS: usize>(pub [u8; ((BITS - 1) >> 3) + 1])
@@ -22,26 +25,26 @@ where
     }
 }
 
-impl<const BITS: usize> std::fmt::LowerHex for BitSet<BITS>
+impl<const BITS: usize> core::fmt::LowerHex for BitSet<BITS>
 where
     [(); ((BITS - 1) >> 3) + 1]:,
 {
     fn fmt(
         &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> Result<(), std::fmt::Error> {
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> Result<(), core::fmt::Error> {
         write!(f, "{:x?}", self.0)
     }
 }
 
-impl<const BITS: usize> std::fmt::UpperHex for BitSet<BITS>
+impl<const BITS: usize> core::fmt::UpperHex for BitSet<BITS>
 where
     [(); ((BITS - 1) >> 3) + 1]:,
 {
     fn fmt(
         &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> Result<(), std::fmt::Error> {
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> Result<(), core::fmt::Error> {
         write!(f, "{:X?}", self.0)
     }
 }
@@ -240,7 +243,7 @@ where
 pub struct OutOfBounds {}
 impl Error for OutOfBounds {}
 impl Display for OutOfBounds {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "out of bounds")
     }
 }
@@ -321,11 +324,11 @@ macro_rules! large_int_small_bitset {
 
 macro_rules! display {
     ($width:expr) => {
-        impl std::fmt::Display for BitSet<$width> {
+        impl core::fmt::Display for BitSet<$width> {
             fn fmt(
                 &self,
-                f: &mut std::fmt::Formatter<'_>,
-            ) -> Result<(), std::fmt::Error> {
+                f: &mut core::fmt::Formatter<'_>,
+            ) -> Result<(), core::fmt::Error> {
                 let i = u64::from(*self);
                 write!(f, "{i}/0x{i:x}/0b{i:b}")
             }
@@ -372,6 +375,7 @@ seq!(N in 1..=64 { display!(N); });
 #[cfg(test)]
 mod test {
     use super::*;
+    use alloc::vec;
     use bitset_macro::bitset;
 
     #[test]


### PR DESCRIPTION
This PR.

- Adds `no_std` support.
- Makes the `mask` operation infallible which bubbles up to `get_field` and `set_field`.